### PR TITLE
Prevent build failure with Parcel v2

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,6 @@
 		<title>Phaser3 + Parceljs Template</title>
 	</head>
 	<body>
-		<script src="main.js"></script>
+		<script src="main.js" type="module"></script>
 	</body>
 </html>


### PR DESCRIPTION
Stops the build error:

@parcel/transformer-js: Browser scripts cannot have imports or exports.